### PR TITLE
Update LLVM-style inline assembly

### DIFF
--- a/bindings/rust/src/asm.rs
+++ b/bindings/rust/src/asm.rs
@@ -1,16 +1,16 @@
 #[inline]
 pub fn cpu_relax() {
-    unsafe { asm!("pause" :::: "volatile") }
+    unsafe { llvm_asm!("pause" :::: "volatile") }
 }
 #[inline]
 pub fn cpu_serialize() {
-    unsafe { asm!("cpuid" : : : "rax", "rbx", "rcx", "rdx": "volatile") }
+    unsafe { llvm_asm!("cpuid" : : : "rax", "rbx", "rcx", "rdx": "volatile") }
 }
 #[inline]
 pub fn rdtsc() -> u64 {
     let a: u32;
     let d: u32;
-    unsafe { asm!("rdtsc" : "={eax}"(a), "={edx}"(d) : : : "volatile" ) };
+    unsafe { llvm_asm!("rdtsc" : "={eax}"(a), "={edx}"(d) : : : "volatile" ) };
     (a as u64) | ((d as u64) << 32)
 }
 #[inline]
@@ -18,7 +18,7 @@ pub fn rdtscp() -> (u64, u32) {
     let a: u32;
     let d: u32;
     let c: u32;
-    unsafe { asm!("rdtscp" : "={eax}"(a), "={edx}"(d), "={ecx}"(c) : : : "volatile") };
+    unsafe { llvm_asm!("rdtscp" : "={eax}"(a), "={edx}"(d), "={ecx}"(c) : : : "volatile") };
 
     ((a as u64) | ((d as u64) << 32), c)
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![feature(asm)]
 #![feature(llvm_asm)]
 #![feature(integer_atomics)]
 #![feature(thread_local)]
@@ -38,8 +37,8 @@ fn convert_error(ret: c_int) -> Result<(), i32> {
 #[inline]
 pub fn preempt_enable() {
     unsafe {
-        asm!("" ::: "memory" : "volatile");
-        asm!("subl $$1, %fs:preempt_cnt@tpoff" : : : "memory", "cc" : "volatile");
+        llvm_asm!("" ::: "memory" : "volatile");
+        llvm_asm!("subl $$1, %fs:preempt_cnt@tpoff" : : : "memory", "cc" : "volatile");
         if ffi::preempt_cnt == 0 {
             ffi::preempt();
         }
@@ -49,8 +48,8 @@ pub fn preempt_enable() {
 #[inline]
 pub fn preempt_disable() {
     unsafe {
-        asm!("addl $$1, %fs:preempt_cnt@tpoff" : : : "memory", "cc" : "volatile");
-        asm!("" ::: "memory" : "volatile");
+        llvm_asm!("addl $$1, %fs:preempt_cnt@tpoff" : : : "memory", "cc" : "volatile");
+        llvm_asm!("" ::: "memory" : "volatile");
     }
 }
 

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![feature(asm)]
+#![feature(llvm_asm)]
 #![feature(integer_atomics)]
 #![feature(thread_local)]
 


### PR DESCRIPTION
Addresses LLVM-style inline assembly deprecated mode, as described in https://github.com/shenango/shenango/issues/3

![image](https://user-images.githubusercontent.com/5385383/110561107-df983780-8125-11eb-8940-f0439744f15f.png)
